### PR TITLE
Add basic unit and route tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,135 @@
+import sys
+import types
+
+# Stub for flask if not installed
+try:
+    import flask  # noqa: F401
+except ModuleNotFoundError:
+    flask_stub = types.ModuleType('flask')
+
+    class Redirect:
+        def __init__(self, location):
+            self.location = location
+
+    class Response:
+        def __init__(self, data='', status_code=200, headers=None):
+            self.data = data.encode() if isinstance(data, str) else data
+            self.status_code = status_code
+            self.headers = headers or {}
+
+    def redirect(location):
+        return Redirect(location)
+
+    import os
+    def render_template(template):
+        path = os.path.join(os.path.dirname(__file__), '..', 'app', 'templates', template)
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                return f.read()
+        except FileNotFoundError:
+            return f'render:{template}'
+
+    def url_for(endpoint):
+        if endpoint == 'tarefa.cadastarTarefa':
+            return '/cadastarTarefa'
+        return '/' + endpoint.split('.')[-1]
+
+    session = {}
+    request = types.SimpleNamespace()
+
+    class Blueprint:
+        def __init__(self, name, import_name):
+            self.name = name
+            self.routes = {}
+
+        def route(self, rule):
+            def decorator(func):
+                self.routes[rule] = func
+                return func
+            return decorator
+
+    class Flask:
+        def __init__(self, name):
+            self.name = name
+            self.routes = {}
+
+        def route(self, rule):
+            def decorator(func):
+                self.routes[rule] = func
+                return func
+            return decorator
+
+        def register_blueprint(self, bp):
+            for rule, func in bp.routes.items():
+                self.routes[rule] = func
+
+        def test_client(self):
+            app = self
+
+            class Client:
+                def get(self, path, follow_redirects=False):
+                    rv = app.routes[path]()
+                    if isinstance(rv, Redirect):
+                        if follow_redirects:
+                            return self.get(rv.location, follow_redirects)
+                        return Response('', 302, {'Location': rv.location})
+                    return Response(rv)
+
+            return Client()
+
+    flask_stub.Flask = Flask
+    flask_stub.Blueprint = Blueprint
+    flask_stub.redirect = redirect
+    flask_stub.url_for = url_for
+    flask_stub.render_template = render_template
+    flask_stub.session = session
+    flask_stub.request = request
+
+    sys.modules['flask'] = flask_stub
+
+# Stub for dotenv if not installed
+try:
+    from dotenv import load_dotenv  # noqa: F401
+except ModuleNotFoundError:
+    dotenv_stub = types.ModuleType('dotenv')
+
+    def load_dotenv():
+        pass
+
+    dotenv_stub.load_dotenv = load_dotenv
+    sys.modules['dotenv'] = dotenv_stub
+
+# Stub for mysql.connector if not installed
+try:
+    import mysql.connector  # noqa: F401
+except ModuleNotFoundError:
+    mysql_stub = types.ModuleType('mysql')
+    connector_stub = types.ModuleType('mysql.connector')
+
+    class Connection:
+        def cursor(self, dictionary=False):
+            return types.SimpleNamespace(
+                execute=lambda query, params=None: None,
+                executemany=lambda query, params=None: None,
+                fetchall=lambda: [],
+                lastrowid=1,
+                close=lambda: None,
+            )
+
+        def commit(self):
+            pass
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            pass
+
+    def connect(**kwargs):
+        return Connection()
+
+    connector_stub.connect = connect
+    mysql_stub.connector = connector_stub
+
+    sys.modules['mysql'] = mysql_stub
+    sys.modules['mysql.connector'] = connector_stub

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.models.database import Database
+
+class TestDatabaseExecute(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault('DB_HOST', 'localhost')
+        os.environ.setdefault('DB_USER', 'user')
+        os.environ.setdefault('DB_PASSWORD', 'password')
+        os.environ.setdefault('DB_NAME', 'test_db')
+
+    @patch('app.models.database.mysql.connector.connect')
+    def test_execute_select(self, mock_connect):
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [{'1': 1}]
+        mock_conn.cursor.return_value = mock_cursor
+        mock_connect.return_value = mock_conn
+
+        db = Database()
+        result = db.execute('SELECT 1', fetch=True)
+
+        self.assertEqual(result, [{'1': 1}])
+        mock_cursor.execute.assert_called_with('SELECT 1', ())
+        mock_conn.cursor.assert_called_with(dictionary=True)
+        mock_cursor.close.assert_called_once()
+        mock_conn.close.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+
+class TestRoutes(unittest.TestCase):
+    def setUp(self):
+        os.environ.setdefault('CHAVE_SESSION', 'test')
+        self.app = create_app()
+        self.client = self.app.test_client()
+
+    def test_index_redirects_to_cadastro(self):
+        response = self.client.get('/', follow_redirects=False)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/cadastarTarefa', response.headers['Location'])
+
+    def test_cadastro_route(self):
+        response = self.client.get('/cadastarTarefa')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Criar Novo Question\xc3\xa1rio', response.data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `tests/` directory with mocks for missing dependencies
- cover `Database.execute` with a simple test
- verify index redirect and cadastro template using Flask test client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c304e4f3c832d9271409f61b13cb0